### PR TITLE
Add portfolio download CLI and web analyzer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,8 @@
 __pycache__/
 portfolio.csv
+Include/
+Lib/
+Scripts/
+share/
+etc/
+*.cfg

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+portfolio.csv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,32 @@
-# tr_analyzer
+# TradeRepublic Portfolio Analyzer
+
+Dieses Projekt bietet eine einfache Möglichkeit, das eigene TradeRepublic-Portfolio
+zu analysieren. Der Download der aktuellen Portfoliozusammensetzung erfolgt über
+die Kommandozeile. Weitere Auswertungen wie Sunburst-Visualisierung und
+Efficient-Frontier-Analyse werden über ein Webinterface bereitgestellt. Zwei
+Sunburst-Diagramme zeigen die Verteilung nach Branchen und nach Ländern, wobei
+der innere Ring nach ETFs und Einzelaktien unterteilt ist. Das Portfolio wird so
+optimiert, dass das Sharpe Ratio maximal ist. Optional können Constraints für
+einzelne Werte gesetzt werden (Format `ISIN<=0.2,ISIN>=0.1`).
+
+## Installation
+
+```bash
+pip install -r requirements.txt
+```
+
+## Portfolio herunterladen
+
+```bash
+python cli.py <telefonnummer> <pin>
+```
+Dies erstellt eine `portfolio.csv` im Projektverzeichnis.
+
+## Weboberfläche starten
+
+```bash
+python app.py
+```
+Anschließend kann die Oberfläche unter `http://localhost:5000` im Browser
+geöffnet werden. Im Formular lassen sich optionale Constraints eingeben, bevor
+die Optimierung gestartet wird.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,108 @@
+"""Simple web application for portfolio analysis."""
+
+import base64
+import io
+from pathlib import Path
+
+import pandas as pd
+import plotly.express as px
+import yfinance as yf
+from flask import Flask, render_template, request
+from matplotlib.figure import Figure
+from pypfopt import EfficientFrontier, expected_returns, risk_models, plotting
+from optimizer import parse_constraints
+
+app = Flask(__name__)
+PORTFOLIO_FILE = Path("portfolio.csv")
+
+
+@app.route("/", methods=["GET", "POST"])
+def index():
+    if not PORTFOLIO_FILE.exists():
+        return "Portfolio file not found. Run the CLI to download your portfolio first."
+
+    df = pd.read_csv(PORTFOLIO_FILE, sep=";")
+    tickers = df["ISIN"].tolist()
+    constraint_str = request.form.get("constraints", "")
+
+    info_rows = []
+    for isin in tickers:
+        ticker = yf.Ticker(isin)
+        info = ticker.info
+        quote_type = info.get("quoteType", "")
+        info_rows.append(
+            {
+                "ISIN": isin,
+                "region": info.get("country", "Unknown"),
+                "sector": info.get("sector", "Unknown"),
+                "asset_type": "ETF" if quote_type == "ETF" else "Stock",
+            }
+        )
+    info_df = pd.DataFrame(info_rows)
+    merged = df.merge(info_df, on="ISIN", how="left")
+
+    fig_sector = px.sunburst(
+        merged,
+        path=["asset_type", "sector", "Name"],
+        values="netValue",
+        title="Allocation by Sector",
+    )
+    fig_country = px.sunburst(
+        merged,
+        path=["asset_type", "region", "Name"],
+        values="netValue",
+        title="Allocation by Country",
+    )
+    sunburst_sector_html = fig_sector.to_html(full_html=False, include_plotlyjs="cdn")
+    sunburst_country_html = fig_country.to_html(full_html=False, include_plotlyjs=False)
+
+    price_data = yf.download(tickers=tickers, period="5y")['Adj Close'].dropna()
+    if price_data.empty or price_data.isnull().all().all():
+        ef_html = "<p>No price data available for efficient frontier.</p>"
+        weights_html = ""
+        perf_html = ""
+    else:
+        mu = expected_returns.mean_historical_return(price_data)
+        S = risk_models.sample_cov(price_data)
+        ef = EfficientFrontier(mu, S)
+
+        for idx, op, val in parse_constraints(constraint_str, tickers):
+            if op == "<=":
+                ef.add_constraint(lambda w, idx=idx, val=val: w[idx] <= val)
+            else:
+                ef.add_constraint(lambda w, idx=idx, val=val: w[idx] >= val)
+
+        fig = Figure()
+        ax = fig.subplots()
+        plotting.plot_efficient_frontier(ef, ax=ax, show_assets=False)
+        buf = io.BytesIO()
+        fig.savefig(buf, format="png")
+        buf.seek(0)
+        ef_html = f'<img src="data:image/png;base64,{base64.b64encode(buf.read()).decode()}"/>'
+
+        ef.max_sharpe()
+        cleaned_weights = ef.clean_weights()
+        weights_df = (
+            pd.Series(cleaned_weights)
+            .reset_index()
+            .rename(columns={"index": "ISIN", 0: "weight"})
+        )
+        weights_html = weights_df.to_html(index=False, float_format="{:.2%}".format)
+        perf = ef.portfolio_performance()
+        perf_html = (
+            f"<p>Return: {perf[0]:.2%}<br>Risk: {perf[1]:.2%}<br>Sharpe: {perf[2]:.2f}</p>"
+        )
+
+    return render_template(
+        "index.html",
+        sunburst_sector=sunburst_sector_html,
+        sunburst_country=sunburst_country_html,
+        ef_plot=ef_html,
+        weights_table=weights_html,
+        perf_html=perf_html,
+        constraints=constraint_str,
+    )
+
+
+if __name__ == "__main__":
+    app.run(debug=True)

--- a/cli.py
+++ b/cli.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""Command line utilities for TradeRepublic portfolio download."""
+
+import argparse
+import asyncio
+from pathlib import Path
+
+from pytr.api import TradeRepublicApi
+from pytr.portfolio import Portfolio
+
+
+def download_portfolio(phone: str, pin: str, output: str = "portfolio.csv") -> Path:
+    """Download the current TradeRepublic portfolio.
+
+    Parameters
+    ----------
+    phone: str
+        Phone number used for TradeRepublic login.
+    pin: str
+        Trading PIN.
+    output: str
+        Path to the CSV file that will be written.
+    """
+    tr = TradeRepublicApi(phone_no=phone, pin=pin)
+    tr.login()
+    pf = Portfolio(tr)
+    asyncio.run(pf.portfolio_loop())
+    output_path = Path(output)
+    pf.portfolio_to_csv(output_path)
+    return output_path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download TradeRepublic portfolio")
+    parser.add_argument("phone", help="Phone number used for TradeRepublic login")
+    parser.add_argument("pin", help="Trading PIN")
+    parser.add_argument(
+        "--output", "-o", default="portfolio.csv", help="Output CSV file path"
+    )
+    args = parser.parse_args()
+    download_portfolio(args.phone, args.pin, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/optimizer.py
+++ b/optimizer.py
@@ -1,0 +1,22 @@
+from typing import List, Tuple
+
+def parse_constraints(constraint_str: str, tickers: List[str]) -> List[Tuple[int, str, float]]:
+    """Parse constraint string into (index, op, value) tuples."""
+    constraints = []
+    for part in constraint_str.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "<=" in part:
+            ticker, val = part.split("<=")
+            op = "<="
+        elif ">=" in part:
+            ticker, val = part.split(">=")
+            op = ">="
+        else:
+            continue
+        ticker = ticker.strip()
+        val = float(val.strip())
+        idx = tickers.index(ticker)
+        constraints.append((idx, op, val))
+    return constraints

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+pytr
+yfinance
+PyPortfolioOpt
+plotly
+flask
+pandas
+numpy

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Portfolio Analyzer</title>
+  </head>
+  <body>
+    <h1>Portfolio Analyzer</h1>
+    <h2>Allocation by Sector</h2>
+    <div>{{ sunburst_sector|safe }}</div>
+    <h2>Allocation by Country</h2>
+    <div>{{ sunburst_country|safe }}</div>
+    <h2>Efficient Frontier</h2>
+    <div>{{ ef_plot|safe }}</div>
+    <h2>Optimierung</h2>
+    <form method="post">
+      <label for="constraints">Constraints (z.B. "ISIN<=0.2,ISIN>=0.1"):</label>
+      <input type="text" id="constraints" name="constraints" value="{{ constraints }}" />
+      <button type="submit">Optimieren</button>
+    </form>
+    <div>{{ weights_table|safe }}</div>
+    <div>{{ perf_html|safe }}</div>
+  </body>
+</html>

--- a/tests/test_placeholder.py
+++ b/tests/test_placeholder.py
@@ -1,0 +1,7 @@
+from optimizer import parse_constraints
+
+
+def test_parse_constraints():
+    tickers = ["AAA", "BBB"]
+    constraints = parse_constraints("AAA<=0.2,BBB>=0.1", tickers)
+    assert constraints == [(0, "<=", 0.2), (1, ">=", 0.1)]


### PR DESCRIPTION
## Summary
- classify holdings into ETFs vs stocks and build separate sunburst charts by sector and by country
- render both allocation sunbursts in the web UI and document the new visualizations
- ignore `portfolio.csv` to avoid committing downloaded portfolio data

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689243818b60832b85620da38f97c1b9