### PR TITLE
Handle missing TradeRepublic signing key

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ Der Befehl startet den Kopplungsprozess und fordert dich auf, den Code
 einzugeben, den TradeRepublic an dein registriertes Gerät sendet. Nach
 erfolgreicher Eingabe ist der Signing-Key gespeichert und das Portfolio kann
 heruntergeladen werden.
+Falls während der Kopplung eine Fehlermeldung zum fehlenden "processId"
+auftaucht, sind möglicherweise Telefonnummer oder PIN falsch oder die
+TradeRepublic-Schnittstelle hat das Format geändert.
 
 ## Portfolio herunterladen
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ einzelne Werte gesetzt werden (Format `ISIN<=0.2,ISIN>=0.1`).
 pip install -r requirements.txt
 ```
 
+## Signing-Key erzeugen
+
+Bevor das Portfolio heruntergeladen werden kann, muss das Gerät einmal mit
+TradeRepublic gekoppelt werden. Dabei wird ein Signing-Key in
+`~/.pytr/keyfile.pem` gespeichert.
+
+```bash
+python cli.py <telefonnummer> <pin> --pair
+```
+
+Der Befehl startet den Kopplungsprozess und fordert dich auf, den Code
+einzugeben, den TradeRepublic an dein registriertes Gerät sendet. Nach
+erfolgreicher Eingabe ist der Signing-Key gespeichert und das Portfolio kann
+heruntergeladen werden.
+
 ## Portfolio herunterladen
 
 ```bash

--- a/cli.py
+++ b/cli.py
@@ -22,6 +22,10 @@ def download_portfolio(phone: str, pin: str, output: str = "portfolio.csv") -> P
         Path to the CSV file that will be written.
     """
     tr = TradeRepublicApi(phone_no=phone, pin=pin)
+    if not hasattr(tr, "sk"):
+        raise RuntimeError(
+            "Signing key not found. Pair your device with TradeRepublic to generate the key file."
+        )
     tr.login()
     pf = Portfolio(tr)
     asyncio.run(pf.portfolio_loop())

--- a/cli.py
+++ b/cli.py
@@ -42,7 +42,13 @@ def pair_device(phone: str, pin: str) -> None:
     the default location used by ``pytr`` (``~/.pytr/keyfile.pem``).
     """
     tr = TradeRepublicApi(phone_no=phone, pin=pin)
-    tr.initiate_device_reset()
+    try:
+        tr.initiate_device_reset()
+    except KeyError as exc:
+        raise RuntimeError(
+            "Failed to initiate device reset; the TradeRepublic API response"
+            " was missing a 'processId'."
+        ) from exc
     token = input("Enter the pairing code sent by TradeRepublic: ")
     tr.complete_device_reset(token)
 

--- a/cli.py
+++ b/cli.py
@@ -34,15 +34,36 @@ def download_portfolio(phone: str, pin: str, output: str = "portfolio.csv") -> P
     return output_path
 
 
+def pair_device(phone: str, pin: str) -> None:
+    """Generate and store a signing key by pairing the device.
+
+    The TradeRepublic backend sends a confirmation code to the registered
+    device. Enter the code when prompted and the signing key will be written to
+    the default location used by ``pytr`` (``~/.pytr/keyfile.pem``).
+    """
+    tr = TradeRepublicApi(phone_no=phone, pin=pin)
+    tr.initiate_device_reset()
+    token = input("Enter the pairing code sent by TradeRepublic: ")
+    tr.complete_device_reset(token)
+
+
 def main() -> None:
-    parser = argparse.ArgumentParser(description="Download TradeRepublic portfolio")
+    parser = argparse.ArgumentParser(description="TradeRepublic utilities")
     parser.add_argument("phone", help="Phone number used for TradeRepublic login")
     parser.add_argument("pin", help="Trading PIN")
     parser.add_argument(
         "--output", "-o", default="portfolio.csv", help="Output CSV file path"
     )
+    parser.add_argument(
+        "--pair",
+        action="store_true",
+        help="Pair device and create signing key instead of downloading portfolio",
+    )
     args = parser.parse_args()
-    download_portfolio(args.phone, args.pin, args.output)
+    if args.pair:
+        pair_device(args.phone, args.pin)
+    else:
+        download_portfolio(args.phone, args.pin, args.output)
 
 
 if __name__ == "__main__":

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -14,3 +14,23 @@ def test_download_portfolio_requires_key(monkeypatch):
     monkeypatch.setattr(cli, "Portfolio", DummyPortfolio)
     with pytest.raises(RuntimeError):
         cli.download_portfolio("123", "456")
+
+
+def test_pair_device(monkeypatch):
+    class DummyPairApi:
+        def __init__(self, *args, **kwargs):
+            self.initiated = False
+            self.token = None
+
+        def initiate_device_reset(self):
+            self.initiated = True
+
+        def complete_device_reset(self, token):
+            self.token = token
+
+    dummy = DummyPairApi()
+    monkeypatch.setattr(cli, "TradeRepublicApi", lambda *a, **kw: dummy)
+    monkeypatch.setattr("builtins.input", lambda prompt="": "123456")
+    cli.pair_device("123", "456")
+    assert dummy.initiated
+    assert dummy.token == "123456"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -34,3 +34,16 @@ def test_pair_device(monkeypatch):
     cli.pair_device("123", "456")
     assert dummy.initiated
     assert dummy.token == "123456"
+
+
+def test_pair_device_handles_missing_process_id(monkeypatch):
+    class FailingPairApi:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def initiate_device_reset(self):
+            raise KeyError("processId")
+
+    monkeypatch.setattr(cli, "TradeRepublicApi", lambda *a, **kw: FailingPairApi())
+    with pytest.raises(RuntimeError):
+        cli.pair_device("123", "456")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+import pytest
+import cli
+
+class DummyApi:
+    def __init__(self, *args, **kwargs):
+        pass
+
+class DummyPortfolio:
+    def __init__(self, *args, **kwargs):
+        raise AssertionError("Portfolio should not be created when signing key is missing")
+
+def test_download_portfolio_requires_key(monkeypatch):
+    monkeypatch.setattr(cli, "TradeRepublicApi", DummyApi)
+    monkeypatch.setattr(cli, "Portfolio", DummyPortfolio)
+    with pytest.raises(RuntimeError):
+        cli.download_portfolio("123", "456")


### PR DESCRIPTION
## Summary
- make `download_portfolio` fail fast when the TradeRepublic signing key is missing
- expose project modules to tests via a simple `tests/__init__`
- add regression test for missing signing key scenario

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898e81cd360832ba595708f7ef37d05